### PR TITLE
Updated Execute Button Text

### DIFF
--- a/fortisoar-soc-simulator/playbooks/playbooks.json
+++ b/fortisoar-soc-simulator/playbooks/playbooks.json
@@ -1039,7 +1039,7 @@
               "description": null,
               "arguments": {
                 "route": "06541acc-eef5-41c4-8abf-ac8db5739e92",
-                "title": "Deploy Scenario",
+                "title": "Simulate Scenario",
                 "resources": [
                   "alerts"
                 ],
@@ -1087,7 +1087,7 @@
                     "filters": []
                   }
                 },
-                "executeButtonText": "Deploy Scenario",
+                "executeButtonText": "Simulate Scenario",
                 "noRecordExecution": true,
                 "singleRecordExecution": false
               },
@@ -1568,7 +1568,7 @@
                     ]
                   }
                 },
-                "executeButtonText": "Execute",
+                "executeButtonText": "Simulate Scenario",
                 "noRecordExecution": false,
                 "singleRecordExecution": true
               },


### PR DESCRIPTION
	In SOC Simulator Connector's sample playbooks change the trigger button name:

Sample - FortiSOAR SOC Simulator - 1.0.8
    - Run Scenario -> Update trigger button to 'Simulate Scenario'
    - Run Selected Scenario -> Update trigger button from 'Deploy Scenario' to 'Simulate Scenario'